### PR TITLE
Fix syntax highlighting for nested directives inside define blocks

### DIFF
--- a/Syntaxes/Makefile.plist
+++ b/Syntaxes/Makefile.plist
@@ -202,6 +202,10 @@
 							<key>include</key>
 							<string>#comment</string>
 						</dict>
+						<dict>
+							<key>include</key>
+							<string>#directives</string>
+						</dict>
 					</array>
 				</dict>
 				<dict>


### PR DESCRIPTION
While it's not a widely used feature of Make, it is valid to nest define/endef blocks within one another arbitrarily in a makefile (at least in the case of GNU Make). This syntax change fixes highlighting of such nested blocks.