### PR TITLE
Fix syntax highlighting of comments with prefixes

### DIFF
--- a/Syntaxes/Makefile.plist
+++ b/Syntaxes/Makefile.plist
@@ -511,6 +511,10 @@
 				</dict>
 				<dict>
 					<key>include</key>
+					<string>#comment</string>
+				</dict>
+				<dict>
+					<key>include</key>
 					<string>#variables</string>
 				</dict>
 			</array>


### PR DESCRIPTION
When a recipe contains a line with only a comment, and a prefix
precedes the comment, the highlighting is invalid (the comment is not
highlighted as such).

This allows comments to appear in recipes.

Fixes #4