### PR TITLE
Prioritize directives over targets

### DIFF
--- a/Syntaxes/Makefile.plist
+++ b/Syntaxes/Makefile.plist
@@ -27,7 +27,7 @@
 		</dict>
 		<dict>
 			<key>include</key>
-			<string>#target</string>
+			<string>#directives</string>
 		</dict>
 		<dict>
 			<key>include</key>
@@ -35,7 +35,7 @@
 		</dict>
 		<dict>
 			<key>include</key>
-			<string>#directives</string>
+			<string>#target</string>
 		</dict>
 	</array>
 	<key>repository</key>


### PR DESCRIPTION
Below line used to be interpreted as Make target with the name `export a ?= b`.
Treat it as directive since this is what Make does.

	export a ?= b:c