### PR TITLE
Adds function call comma separators

### DIFF
--- a/Syntaxes/Makefile.plist
+++ b/Syntaxes/Makefile.plist
@@ -745,6 +745,12 @@
 						</dict>
 						<dict>
 							<key>match</key>
+							<string>,</string>
+							<key>name</key>
+							<string>punctuation.separator.comma.makefile</string>
+						</dict>
+						<dict>
+							<key>match</key>
 							<string>%|\*</string>
 							<key>name</key>
 							<string>constant.other.placeholder.makefile</string>


### PR DESCRIPTION
So this:

<img width="890" alt="Screen Shot 1400-06-15 at 19 11 45" src="https://user-images.githubusercontent.com/2157285/132238973-4a148268-8a31-4099-a505-2826957aa1a0.png">

Becomes this:

<img width="950" alt="Screen Shot 1400-06-15 at 19 06 28" src="https://user-images.githubusercontent.com/2157285/132238993-b2372500-dad1-43df-ba71-4ec1e3ae6b9d.png">
